### PR TITLE
fix: base and dev requirements and show send async option

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,10 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
-django-statici18n
-edx-i18n-tools
-Mako
-transifex-client
 XBlock 
 xblock-utils
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,41 +5,20 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via fs
-certifi==2021.5.30        # via requests
-chardet==4.0.0            # via requests
-django-appconf==1.0.4     # via django-statici18n
-django-statici18n==2.0.1  # via -r requirements/base.in
-django==2.2.24            # via django-appconf, django-statici18n, edx-i18n-tools
-edx-i18n-tools==0.5.3     # via -r requirements/base.in
 fs==2.4.13                # via xblock
-gitdb==4.0.7              # via gitpython
-gitpython==3.1.14         # via transifex-client
-idna==2.10                # via requests
-importlib-metadata==2.1.1  # via path
 lxml==4.6.3               # via xblock
-mako==1.1.4               # via -r requirements/base.in, xblock-utils
+mako==1.1.4               # via xblock-utils
 markupsafe==1.1.1         # via mako, xblock
-path.py==12.5.0           # via edx-i18n-tools
-path==13.1.0              # via path.py
-polib==1.1.1              # via edx-i18n-tools
-python-dateutil==2.8.1    # via xblock
-python-slugify==4.0.1     # via transifex-client
-pytz==2021.1              # via django, fs, xblock
-pyyaml==5.3.1             # via edx-i18n-tools, xblock
-requests==2.25.1          # via transifex-client
+python-dateutil==2.8.2    # via xblock
+pytz==2021.1              # via fs, xblock
+pyyaml==5.3.1             # via xblock
 simplejson==3.17.3        # via xblock-utils
-six==1.16.0               # via edx-i18n-tools, fs, python-dateutil, transifex-client
-smmap==4.0.0              # via gitdb
-sqlparse==0.4.1           # via django
-text-unidecode==1.3       # via python-slugify
-transifex-client==0.14.3  # via -r requirements/base.in
+six==1.16.0               # via fs, python-dateutil
 typing==3.7.4.3           # via fs
-urllib3==1.26.6           # via requests, transifex-client
 web-fragments==1.1.0      # via xblock, xblock-utils
 webob==1.8.7              # via xblock
 xblock-utils==2.1.3       # via -r requirements/base.in
 xblock==1.4.2             # via -r requirements/base.in, xblock-utils
-zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,7 +22,7 @@ pyparsing==2.4.7          # via packaging
 requests==2.25.1          # via codecov
 six==1.16.0               # via tox, virtualenv
 toml==0.10.2              # via tox
-tox==3.23.1               # via -r requirements/ci.in
+tox==3.24.0               # via -r requirements/ci.in
 urllib3==1.26.6           # via requests
-virtualenv==20.5.0        # via tox
+virtualenv==20.6.0        # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,3 +11,6 @@
 # Keep the same version as the platform and maintain support for python 3.5
 click==7.1.2
 pip-tools==4.5.1
+
+# Versions > 20.0.2 are not compatible with pip-tools 4.5.1
+pip==20.0.2

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,3 +7,8 @@
 
 diff-cover                # Changeset diff test coverage
 tox-battery               # Makes tox aware of requirements file changes
+django-statici18n
+edx-i18n-tools
+Mako
+transifex-client
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4            # via -r requirements/quality.txt, fs
 astroid==2.4.2            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==21.2.0             # via -r requirements/quality.txt, pytest
 backports.entry-points-selectable==1.1.0  # via -r requirements/ci.txt, virtualenv
-bleach==3.3.0             # via -r requirements/quality.txt, readme-renderer
+bleach==3.3.1             # via -r requirements/quality.txt, readme-renderer
 certifi==2021.5.30        # via -r requirements/ci.txt, -r requirements/quality.txt, requests
 chardet==4.0.0            # via -r requirements/ci.txt, -r requirements/quality.txt, diff-cover, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
@@ -18,16 +18,16 @@ codecov==2.1.11           # via -r requirements/ci.txt
 coverage==5.5             # via -r requirements/ci.txt, -r requirements/quality.txt, codecov, pytest-cov
 diff-cover==4.2.3         # via -r requirements/dev.in
 distlib==0.3.2            # via -r requirements/ci.txt, virtualenv
-django-appconf==1.0.4     # via -r requirements/quality.txt, django-statici18n
-django-statici18n==2.0.1  # via -r requirements/quality.txt
+django-appconf==1.0.4     # via django-statici18n
+django-statici18n==2.0.1  # via -r requirements/dev.in
 django==2.2.24            # via -r requirements/quality.txt, django-appconf, django-statici18n, edx-i18n-tools, edx-lint
 docutils==0.17.1          # via -r requirements/quality.txt, readme-renderer
-edx-i18n-tools==0.5.3     # via -r requirements/quality.txt
+edx-i18n-tools==0.7.0     # via -r requirements/dev.in
 edx-lint==5.0.0           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/ci.txt, tox, virtualenv
 fs==2.4.13                # via -r requirements/quality.txt, xblock
-gitdb==4.0.7              # via -r requirements/quality.txt, gitpython
-gitpython==3.1.14         # via -r requirements/quality.txt, transifex-client
+gitdb==4.0.7              # via gitpython
+gitpython==3.1.14         # via transifex-client
 idna==2.10                # via -r requirements/ci.txt, -r requirements/quality.txt, requests
 importlib-metadata==2.1.1  # via -r requirements/ci.txt, -r requirements/quality.txt, backports.entry-points-selectable, inflect, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.2.1  # via -r requirements/ci.txt, virtualenv
@@ -38,19 +38,18 @@ jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.3            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 lxml==4.6.3               # via -r requirements/quality.txt, xblock
-mako==1.1.4               # via -r requirements/quality.txt, xblock-utils
+mako==1.1.4               # via -r requirements/dev.in, -r requirements/quality.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2, mako, xblock
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 packaging==20.9           # via -r requirements/ci.txt, -r requirements/quality.txt, bleach, pytest, tox
-path.py==12.5.0           # via -r requirements/quality.txt, edx-i18n-tools
-path==13.1.0              # via -r requirements/quality.txt, path.py
+path==13.1.0              # via edx-i18n-tools
 pathlib2==2.3.6           # via -r requirements/quality.txt, pytest
 pbr==5.6.0                # via -r requirements/quality.txt, stevedore
 pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/pip-tools.txt
 pkginfo==1.7.1            # via -r requirements/quality.txt, twine
 platformdirs==2.0.2       # via -r requirements/ci.txt, virtualenv
 pluggy==0.13.1            # via -r requirements/ci.txt, -r requirements/quality.txt, diff-cover, pytest, tox
-polib==1.1.1              # via -r requirements/quality.txt, edx-i18n-tools
+polib==1.1.1              # via edx-i18n-tools
 py==1.10.0                # via -r requirements/ci.txt, -r requirements/quality.txt, pytest, tox
 pycodestyle==2.7.0        # via -r requirements/quality.txt
 pydocstyle==5.1.1         # via -r requirements/quality.txt
@@ -62,7 +61,7 @@ pylint==2.6.2             # via -r requirements/quality.txt, edx-lint, pylint-ce
 pyparsing==2.4.7          # via -r requirements/ci.txt, -r requirements/quality.txt, packaging
 pytest-cov==2.12.1        # via -r requirements/quality.txt
 pytest==6.1.2             # via -r requirements/quality.txt, pytest-cov
-python-dateutil==2.8.1    # via -r requirements/quality.txt, xblock
+python-dateutil==2.8.2    # via -r requirements/quality.txt, xblock
 python-slugify==4.0.1     # via -r requirements/quality.txt, code-annotations, transifex-client
 pytz==2021.1              # via -r requirements/quality.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-i18n-tools, xblock
@@ -71,21 +70,21 @@ requests-toolbelt==0.9.1  # via -r requirements/quality.txt, twine
 requests==2.25.1          # via -r requirements/ci.txt, -r requirements/quality.txt, codecov, requests-toolbelt, transifex-client, twine
 simplejson==3.17.3        # via -r requirements/quality.txt, xblock-utils
 six==1.16.0               # via -r requirements/ci.txt, -r requirements/pip-tools.txt, -r requirements/quality.txt, astroid, bleach, edx-i18n-tools, edx-lint, fs, pathlib2, pip-tools, python-dateutil, readme-renderer, stevedore, tox, transifex-client, virtualenv
-smmap==4.0.0              # via -r requirements/quality.txt, gitdb
+smmap==4.0.0              # via gitdb
 snowballstemmer==2.1.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.4.1           # via -r requirements/quality.txt, django
 stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations
 text-unidecode==1.3       # via -r requirements/quality.txt, python-slugify
 toml==0.10.2              # via -r requirements/ci.txt, -r requirements/quality.txt, pylint, pytest, pytest-cov, tox
 tox-battery==0.6.1        # via -r requirements/dev.in
-tox==3.23.1               # via -r requirements/ci.txt, tox-battery
+tox==3.24.0               # via -r requirements/ci.txt, tox-battery
 tqdm==4.61.2              # via -r requirements/quality.txt, twine
-transifex-client==0.14.3  # via -r requirements/quality.txt
+transifex-client==0.14.3  # via -r requirements/dev.in
 twine==1.15.0             # via -r requirements/quality.txt
 typed-ast==1.4.3          # via -r requirements/quality.txt, astroid
 typing==3.7.4.3           # via -r requirements/quality.txt, fs
 urllib3==1.26.6           # via -r requirements/ci.txt, -r requirements/quality.txt, requests, transifex-client
-virtualenv==20.5.0        # via -r requirements/ci.txt, tox
+virtualenv==20.6.0        # via -r requirements/ci.txt, tox
 web-fragments==1.1.0      # via -r requirements/quality.txt, xblock, xblock-utils
 webencodings==0.5.1       # via -r requirements/quality.txt, bleach
 webob==1.8.7              # via -r requirements/quality.txt, xblock

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,50 +8,39 @@ alabaster==0.7.12         # via sphinx
 appdirs==1.4.4            # via -r requirements/test.txt, fs
 attrs==21.2.0             # via -r requirements/test.txt, pytest
 babel==2.9.1              # via sphinx
-bleach==3.3.0             # via readme-renderer
-certifi==2021.5.30        # via -r requirements/test.txt, requests
-chardet==4.0.0            # via -r requirements/test.txt, doc8, requests
+bleach==3.3.1             # via readme-renderer
+certifi==2021.5.30        # via requests
+chardet==4.0.0            # via doc8, requests
 coverage==5.5             # via -r requirements/test.txt, pytest-cov
-django-appconf==1.0.4     # via -r requirements/test.txt, django-statici18n
-django-statici18n==2.0.1  # via -r requirements/test.txt
-django==2.2.24            # via -r requirements/test.txt, django-appconf, django-statici18n, edx-i18n-tools
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0   # via -r requirements/doc.in
 fs==2.4.13                # via -r requirements/test.txt, xblock
-gitdb==4.0.7              # via -r requirements/test.txt, gitpython
-gitpython==3.1.14         # via -r requirements/test.txt, transifex-client
-idna==2.10                # via -r requirements/test.txt, requests
+idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.1.1  # via -r requirements/test.txt, path, pluggy, pytest
+importlib-metadata==2.1.1  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.3            # via sphinx
 lxml==4.6.3               # via -r requirements/test.txt, xblock
 mako==1.1.4               # via -r requirements/test.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2, mako, xblock
 packaging==20.9           # via -r requirements/test.txt, bleach, pytest, sphinx
-path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
-path==13.1.0              # via -r requirements/test.txt, path.py
 pathlib2==2.3.6           # via -r requirements/test.txt, pytest
 pbr==5.6.0                # via stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-polib==1.1.1              # via -r requirements/test.txt, edx-i18n-tools
 py==1.10.0                # via -r requirements/test.txt, pytest
 pygments==2.9.0           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.12.1        # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-cov
-python-dateutil==2.8.1    # via -r requirements/test.txt, xblock
-python-slugify==4.0.1     # via -r requirements/test.txt, transifex-client
-pytz==2021.1              # via -r requirements/test.txt, babel, django, fs, xblock
-pyyaml==5.3.1             # via -r requirements/test.txt, edx-i18n-tools, xblock
+python-dateutil==2.8.2    # via -r requirements/test.txt, xblock
+pytz==2021.1              # via -r requirements/test.txt, babel, fs, xblock
+pyyaml==5.3.1             # via -r requirements/test.txt, xblock
 readme-renderer==29.0     # via -r requirements/doc.in
-requests==2.25.1          # via -r requirements/test.txt, sphinx, transifex-client
+requests==2.25.1          # via sphinx
 restructuredtext-lint==1.3.2  # via doc8
 simplejson==3.17.3        # via -r requirements/test.txt, xblock-utils
-six==1.16.0               # via -r requirements/test.txt, bleach, doc8, edx-i18n-tools, edx-sphinx-theme, fs, pathlib2, python-dateutil, readme-renderer, stevedore, transifex-client
-smmap==4.0.0              # via -r requirements/test.txt, gitdb
+six==1.16.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, fs, pathlib2, python-dateutil, readme-renderer, stevedore
 snowballstemmer==2.1.0    # via sphinx
 sphinx==3.5.4             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -60,13 +49,10 @@ sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.5  # via sphinx
-sqlparse==0.4.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via doc8
-text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, pytest, pytest-cov
-transifex-client==0.14.3  # via -r requirements/test.txt
 typing==3.7.4.3           # via -r requirements/test.txt, fs
-urllib3==1.26.6           # via -r requirements/test.txt, requests, transifex-client
+urllib3==1.26.6           # via requests
 web-fragments==1.1.0      # via -r requirements/test.txt, xblock, xblock-utils
 webencodings==0.5.1       # via bleach
 webob==1.8.7              # via -r requirements/test.txt, xblock

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -7,24 +7,19 @@
 appdirs==1.4.4            # via -r requirements/test.txt, fs
 astroid==2.4.2            # via pylint, pylint-celery
 attrs==21.2.0             # via -r requirements/test.txt, pytest
-bleach==3.3.0             # via readme-renderer
-certifi==2021.5.30        # via -r requirements/test.txt, requests
-chardet==4.0.0            # via -r requirements/test.txt, requests
+bleach==3.3.1             # via readme-renderer
+certifi==2021.5.30        # via requests
+chardet==4.0.0            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -c requirements/constraints.txt, click-log, code-annotations, edx-lint
 code-annotations==1.1.2   # via edx-lint
 coverage==5.5             # via -r requirements/test.txt, pytest-cov
-django-appconf==1.0.4     # via -r requirements/test.txt, django-statici18n
-django-statici18n==2.0.1  # via -r requirements/test.txt
-django==2.2.24            # via -r requirements/test.txt, django-appconf, django-statici18n, edx-i18n-tools, edx-lint
+django==2.2.24            # via edx-lint
 docutils==0.17.1          # via readme-renderer
-edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-lint==5.0.0           # via -r requirements/quality.in
 fs==2.4.13                # via -r requirements/test.txt, xblock
-gitdb==4.0.7              # via -r requirements/test.txt, gitpython
-gitpython==3.1.14         # via -r requirements/test.txt, transifex-client
-idna==2.10                # via -r requirements/test.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/test.txt, path, pluggy, pytest
+idna==2.10                # via requests
+importlib-metadata==2.1.1  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2==2.11.3            # via code-annotations
@@ -34,13 +29,10 @@ mako==1.1.4               # via -r requirements/test.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2, mako, xblock
 mccabe==0.6.1             # via pylint
 packaging==20.9           # via -r requirements/test.txt, bleach, pytest
-path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
-path==13.1.0              # via -r requirements/test.txt, path.py
 pathlib2==2.3.6           # via -r requirements/test.txt, pytest
 pbr==5.6.0                # via stevedore
 pkginfo==1.7.1            # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-polib==1.1.1              # via -r requirements/test.txt, edx-i18n-tools
 py==1.10.0                # via -r requirements/test.txt, pytest
 pycodestyle==2.7.0        # via -r requirements/quality.in
 pydocstyle==5.1.1         # via -r requirements/quality.in
@@ -52,27 +44,25 @@ pylint==2.6.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.12.1        # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-cov
-python-dateutil==2.8.1    # via -r requirements/test.txt, xblock
-python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations, transifex-client
+python-dateutil==2.8.2    # via -r requirements/test.txt, xblock
+python-slugify==4.0.1     # via code-annotations
 pytz==2021.1              # via -r requirements/test.txt, django, fs, xblock
-pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-i18n-tools, xblock
+pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, xblock
 readme-renderer==29.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.25.1          # via -r requirements/test.txt, requests-toolbelt, transifex-client, twine
+requests==2.25.1          # via requests-toolbelt, twine
 simplejson==3.17.3        # via -r requirements/test.txt, xblock-utils
-six==1.16.0               # via -r requirements/test.txt, astroid, bleach, edx-i18n-tools, edx-lint, fs, pathlib2, python-dateutil, readme-renderer, stevedore, transifex-client
-smmap==4.0.0              # via -r requirements/test.txt, gitdb
+six==1.16.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, fs, pathlib2, python-dateutil, readme-renderer, stevedore
 snowballstemmer==2.1.0    # via pydocstyle
-sqlparse==0.4.1           # via -r requirements/test.txt, django
+sqlparse==0.4.1           # via django
 stevedore==1.32.0         # via code-annotations
-text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
+text-unidecode==1.3       # via python-slugify
 toml==0.10.2              # via -r requirements/test.txt, pylint, pytest, pytest-cov
 tqdm==4.61.2              # via twine
-transifex-client==0.14.3  # via -r requirements/test.txt
 twine==1.15.0             # via -r requirements/quality.in
 typed-ast==1.4.3          # via astroid
 typing==3.7.4.3           # via -r requirements/test.txt, fs
-urllib3==1.26.6           # via -r requirements/test.txt, requests, transifex-client
+urllib3==1.26.6           # via requests
 web-fragments==1.1.0      # via -r requirements/test.txt, xblock, xblock-utils
 webencodings==0.5.1       # via bleach
 webob==1.8.7              # via -r requirements/test.txt, xblock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,51 +6,32 @@
 #
 appdirs==1.4.4            # via -r requirements/base.txt, fs
 attrs==21.2.0             # via pytest
-certifi==2021.5.30        # via -r requirements/base.txt, requests
-chardet==4.0.0            # via -r requirements/base.txt, requests
 coverage==5.5             # via pytest-cov
-django-appconf==1.0.4     # via -r requirements/base.txt, django-statici18n
-django-statici18n==2.0.1  # via -r requirements/base.txt
-django==2.2.24            # via -r requirements/base.txt, django-appconf, django-statici18n, edx-i18n-tools
-edx-i18n-tools==0.5.3     # via -r requirements/base.txt
 fs==2.4.13                # via -r requirements/base.txt, xblock
-gitdb==4.0.7              # via -r requirements/base.txt, gitpython
-gitpython==3.1.14         # via -r requirements/base.txt, transifex-client
-idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/base.txt, path, pluggy, pytest
+importlib-metadata==2.1.1  # via pluggy, pytest
 iniconfig==1.1.1          # via pytest
 lxml==4.6.3               # via -r requirements/base.txt, xblock
 mako==1.1.4               # via -r requirements/base.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/base.txt, mako, xblock
 packaging==20.9           # via pytest
-path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
-path==13.1.0              # via -r requirements/base.txt, path.py
 pathlib2==2.3.6           # via pytest
 pluggy==0.13.1            # via pytest
-polib==1.1.1              # via -r requirements/base.txt, edx-i18n-tools
 py==1.10.0                # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.12.1        # via -r requirements/test.in
 pytest==6.1.2             # via pytest-cov
-python-dateutil==2.8.1    # via -r requirements/base.txt, xblock
-python-slugify==4.0.1     # via -r requirements/base.txt, transifex-client
-pytz==2021.1              # via -r requirements/base.txt, django, fs, xblock
-pyyaml==5.3.1             # via -r requirements/base.txt, edx-i18n-tools, xblock
-requests==2.25.1          # via -r requirements/base.txt, transifex-client
+python-dateutil==2.8.2    # via -r requirements/base.txt, xblock
+pytz==2021.1              # via -r requirements/base.txt, fs, xblock
+pyyaml==5.3.1             # via -r requirements/base.txt, xblock
 simplejson==3.17.3        # via -r requirements/base.txt, xblock-utils
-six==1.16.0               # via -r requirements/base.txt, edx-i18n-tools, fs, pathlib2, python-dateutil, transifex-client
-smmap==4.0.0              # via -r requirements/base.txt, gitdb
-sqlparse==0.4.1           # via -r requirements/base.txt, django
-text-unidecode==1.3       # via -r requirements/base.txt, python-slugify
+six==1.16.0               # via -r requirements/base.txt, fs, pathlib2, python-dateutil
 toml==0.10.2              # via pytest, pytest-cov
-transifex-client==0.14.3  # via -r requirements/base.txt
 typing==3.7.4.3           # via -r requirements/base.txt, fs
-urllib3==1.26.6           # via -r requirements/base.txt, requests, transifex-client
 web-fragments==1.1.0      # via -r requirements/base.txt, xblock, xblock-utils
 webob==1.8.7              # via -r requirements/base.txt, xblock
 xblock-utils==2.1.3       # via -r requirements/base.txt
 xblock==1.4.2             # via -r requirements/base.txt, xblock-utils
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/webhook_xblock/static/html/webhook_xblock_edit.html
+++ b/webhook_xblock/static/html/webhook_xblock_edit.html
@@ -56,13 +56,12 @@
         </div>
         <span class="tip setting-help">Send the student's course grade in the payload.</span>
     </li>
-    <!-- Hide this field until we can figure out how to send the async task -->
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <!--<label class="label setting-label" for="webhook_xblock_send_async">Send in Async Task</label>-->
-        <input class="input setting-input-bool" name="webhook_xblock_send_async" id="webhook_xblock_send_async" value="{send_async}" type="hidden" />
+        <label class="label setting-label" for="webhook_xblock_send_async">Send in Async Task</label>
+        <input class="input setting-input-bool" name="webhook_xblock_send_async" id="webhook_xblock_send_async" value="{send_async}" type="checkbox" />
       </div>
-      <!--<span class="tip setting-help">Send the payload in an async task.</span>-->
+      <span class="tip setting-help">Send the payload in an async task.</span>
     </li>
   </ul>
   <div class="xblock-actions">

--- a/webhook_xblock/tasks.py
+++ b/webhook_xblock/tasks.py
@@ -10,7 +10,6 @@ from webhook_xblock.constants import REQUEST_TIMEOUT
 
 LOGGER = get_task_logger(__name__)
 
-RETRY_DELAY = 5 * 60
 MAX_RETRIES = 3
 
 


### PR DESCRIPTION
Unnecessary base.py requirements were removed.

Also, turns out that the problem with the async tasks was that I needed to install the xblock in the lms_worker container.
I tested sending the payload async and it works just fine, that's why I'm removing the comments to enable again de _send async_ option

Special thanks to @andrey-canon 