### PR TITLE
fix: Input of Type Checkbox and Async task to send the payload

### DIFF
--- a/webhook_xblock/static/css/webhook_xblock.css
+++ b/webhook_xblock/static/css/webhook_xblock.css
@@ -9,3 +9,34 @@
     color: red;
     display: inline;
 }
+
+input[type=checkbox] {
+    position: relative;
+      cursor: pointer;
+}
+input[type=checkbox]:before {
+    content: "";
+    display: block;
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    top: 0;
+    left: 0;
+    border: 1px solid #555555;
+    border-radius: 3px;
+    background-color: white;
+}
+input[type=checkbox]:checked:after {
+    content: "";
+    display: block;
+    width: 5px;
+    height: 10px;
+    border: solid #3391c3;
+    border-width: 0 2px 2px 0;
+    -webkit-transform: rotate(45deg);
+    -ms-transform: rotate(45deg);
+    transform: rotate(45deg);
+    position: absolute;
+    top: 2px;
+    left: 6px;
+}

--- a/webhook_xblock/static/html/webhook_xblock_edit.html
+++ b/webhook_xblock/static/html/webhook_xblock_edit.html
@@ -56,13 +56,12 @@
         </div>
         <span class="tip setting-help">Send the student's course grade in the payload.</span>
     </li>
-    <!-- Hide this field until we can figure out how to send the async task -->
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <!--<label class="label setting-label" for="webhook_xblock_send_async">Send in Async Task</label>-->
-        <input class="input setting-input-bool" name="webhook_xblock_send_async" id="webhook_xblock_send_async" value="{send_async}" type="hidden" />
+        <label class="label setting-label" for="webhook_xblock_send_async">Send in Async Task</label>
+        <input class="input setting-input-bool" name="webhook_xblock_send_async" id="webhook_xblock_send_async" value="{send_async}" type="checkbox" />
       </div>
-      <!--<span class="tip setting-help">Send the payload in an async task.</span>-->
+      <span class="tip setting-help">Send the payload in an async task.</span>
     </li>
   </ul>
   <div class="xblock-actions">

--- a/webhook_xblock/tasks.py
+++ b/webhook_xblock/tasks.py
@@ -14,32 +14,43 @@ RETRY_DELAY = 5 * 60
 MAX_RETRIES = 3
 
 
-@shared_task(
-    bind=True,
-    autoretry_for=(Timeout),
-    retry_backoff=True,
-    retry_kwargs={
-        "max_retries": MAX_RETRIES,
-    },
-)
+@shared_task(bind=True, max_retries=MAX_RETRIES)
 def task_send_payload(self, data, url):  # pylint: disable=unused-argument
     """
     Task that Triggers the webhook and sends the payload
     """
     course_id = data.get("course_id")
 
-    response = requests.post(
-        url=url,
-        data=data,
-        timeout=REQUEST_TIMEOUT,
-    )
+    try:
+        response = requests.post(
+            url=url,
+            data=data,
+            timeout=REQUEST_TIMEOUT,
+        )
 
-    if response.ok:
-        return True
-    else:
-        LOGGER.error("Webhook-Xblock request FAILED for course {course}. status {code} - {msg}".format(
-            code=response.status_code,
-            msg=getattr(response, "text", ""),
-            course=course_id,
+        if response.ok:
+            return True
+        else:
+            LOGGER.error("Webhook-Xblock request FAILED for course {course}. status {code} - {msg}".format(
+                code=response.status_code,
+                msg=getattr(response, "text", ""),
+                course=course_id,
+            ))
+            return False
+    except Exception as exc:  # pylint: disable=broad-except
+        retry_task(self, exc, url)
+
+
+def retry_task(task, exception, url):
+    """
+    Calls the task to run again in case it has not exceeded the
+    number of max_retries.
+    """
+    if task.request.retries >= task.max_retries:
+        LOGGER.error("Could not send payload to {url}. MAX RETRIES EXCEEDED".format(
+            url=url
         ))
         return False
+
+    raise task.retry(exc=exception, countdown=RETRY_DELAY)
+

--- a/webhook_xblock/webhook_xblock.py
+++ b/webhook_xblock/webhook_xblock.py
@@ -219,6 +219,7 @@ class WebhookXblock(XBlock):
             course_id = str(self.runtime.course_id)
             student = self.runtime.get_real_user(current_anonymous_student_id)
             serialized_student = AccountUserSerializer(student)
+            response = False
 
             payload = {
                 "payload_name": self.name,


### PR DESCRIPTION
The checkboxes in the studio view were not displaying properly for Chrome. This was fixed by adding some customization to the CSS file.
Before (Chrome)
![chrome1](https://user-images.githubusercontent.com/35777155/139333519-d475ccf4-4ad8-4cfd-9ccb-ef7bdd8e85bb.png)

After (Chrome)
![chrome2](https://user-images.githubusercontent.com/35777155/139333597-053e54b0-1dd4-46a4-9593-91e4cc3b5f4d.png)


Also, since **autoretry_for** is not available for celery<4.0.0, the async task would raise an exception on a failure. This was fixed by removing the parameter and adding a new method for retry
