### PR TITLE
refactor: replace deprecated pkg_resources API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,18 @@ Unreleased
 
 *
 
+1.0.1 - 2025-02-04
+**********************************************
+
+Changed
+=======
+
+* **Replaced `pkg_resources` with `importlib.resources`**  
+  - `pkg_resources` (from `setuptools`) is deprecated and may be removed in future Python versions.  
+  - Now using `importlib.resources`, the recommended alternative for managing package resources.  
+  - This improves performance and ensures better compatibility with modern Python versions.  
+
+
 [1.0.0] - 2025-01-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/webhook_xblock/__init__.py
+++ b/webhook_xblock/__init__.py
@@ -3,4 +3,4 @@ Init file for webhook xblock.
 """
 from .webhook_xblock import WebhookXblock
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/webhook_xblock/webhook_xblock.py
+++ b/webhook_xblock/webhook_xblock.py
@@ -16,7 +16,6 @@ from opaque_keys.edx.keys import CourseKey
 from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Scope, String
 from xblock.fragment import Fragment
-from xblockutils.resources import ResourceLoader
 
 from webhook_xblock.constants import REQUEST_TIMEOUT
 from webhook_xblock.edxapp_wrapper.grade import get_student_course_grade
@@ -304,7 +303,6 @@ class WebhookXblock(XBlock):  # pylint: disable=too-many-instance-attributes
         text_js = 'public/js/translations/{locale_code}/text.js'
         lang_code = locale_code.split('-')[0]
         for code in (locale_code, lang_code, 'en'):
-            loader = ResourceLoader(__name__)
             if importlib_files(__package__).joinpath(text_js.format(locale_code=code)).exists():
                 return text_js.format(locale_code=code)
         return None

--- a/webhook_xblock/webhook_xblock.py
+++ b/webhook_xblock/webhook_xblock.py
@@ -8,7 +8,7 @@ import datetime
 import json
 import logging
 
-import pkg_resources
+from importlib.resources import files as importlib_files
 import requests
 from django.contrib.auth import get_user_model
 from django.utils import translation
@@ -82,8 +82,7 @@ class WebhookXblock(XBlock):  # pylint: disable=too-many-instance-attributes
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
-        data = pkg_resources.resource_string(__name__, path)
-        return data.decode("utf8")
+        return importlib_files(__package__).joinpath(path).read_text(encoding="utf-8")
 
     def check_if_running_from_studio(self):
         """
@@ -306,8 +305,7 @@ class WebhookXblock(XBlock):  # pylint: disable=too-many-instance-attributes
         lang_code = locale_code.split('-')[0]
         for code in (locale_code, lang_code, 'en'):
             loader = ResourceLoader(__name__)
-            if pkg_resources.resource_exists(
-                    loader.module_name, text_js.format(locale_code=code)):
+            if importlib_files(__package__).joinpath(text_js.format(locale_code=code)).exists():
                 return text_js.format(locale_code=code)
         return None
 

--- a/webhook_xblock/webhook_xblock.py
+++ b/webhook_xblock/webhook_xblock.py
@@ -7,8 +7,8 @@ student to a configurable URL, when visiting a specific course unit.
 import datetime
 import json
 import logging
-
 from importlib.resources import files as importlib_files
+
 import requests
 from django.contrib.auth import get_user_model
 from django.utils import translation


### PR DESCRIPTION
# Description

pkg_resources (from setuptools) is [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) and will be removed in future Python versions.
The new implementation uses importlib.resources, which is the recommended alternative and is fully available in Python 3.9+.

# How to test

1, Create a Sumac environment using Tutor or TVM.
2. Install webhook-xblock using this branch you can follow the official [tutor documentation](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).
3. In a course of study:
Navigate to Settings -> Advanced Settings and go to Advanced Module List settings.
Add:
[ "webhook-xblock" ]

# Other Information

https://github.com/openedx/public-engineering/issues/273